### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ is found in this directory hierarchy.
 ```elisp
 (eval-after-load "python"
   '(progn
-     (define-key pythom-mode-map (kbd "C-c C-d") 'helm-pydoc)))
+     (define-key python-mode-map (kbd "C-c C-d") 'helm-pydoc)))
 ```


### PR DESCRIPTION
The snippet from the README file had a typo which stopped it from being evaled correctly.

Happy holidays, btw!
