### PR TITLE
Use /Scripts/python instead of /bin/python on Windows

### DIFF
--- a/helm-pydoc.el
+++ b/helm-pydoc.el
@@ -48,7 +48,9 @@
            (venv (locate-dominating-file file helm-pydoc-virtualenv)))
       (if venv
           (concat (expand-file-name (file-name-as-directory venv))
-                  helm-pydoc-virtualenv "/bin/python")
+                  helm-pydoc-virtualenv (if (eq system-type 'windows-nt)
+                                            "/Scripts/python"
+                                          "/bin/python"))
         python-shell-interpreter))))
 
 (defun helm-pydoc--collect-imported-modules ()


### PR DESCRIPTION
Hi!

On Windows, python is in `venv/Scripts/python` instead of `venv/bin/python`, this PR corrects that.
Do you think this is good enough to merge?

Thanks