### PR TITLE
run pydoc for symbol at point or region

### DIFF
--- a/helm-pydoc.el
+++ b/helm-pydoc.el
@@ -182,6 +182,16 @@
   (helm :sources '(helm-pydoc--imported-source helm-pydoc--installed-source)
         :buffer "*helm pydoc*" :history 'helm-pydoc--history))
 
+;;;###autoload
+(defun helm-pydoc-at-point ()
+  (interactive)
+  (let ((symbol
+	 (if (region-active-p)
+	     (buffer-substring (region-beginning) (region-end))
+	   (current-word))))
+    (helm :sources '(helm-pydoc--imported-source helm-pydoc--installed-source)
+	  :buffer "*helm pydoc*" :history 'helm-pydoc--history :input symbol)))
+
 (provide 'helm-pydoc)
 
 ;;; helm-pydoc.el ends here


### PR DESCRIPTION
So basically want this feature

https://github.com/statmobile/pydoc/blob/master/pydoc.el#L754

however the above requires jedi, while your implementation seems to not require anything which is why I prefer it.  I guess it seems odd to generate a helm list with one candidate but helm is so integrated into my workflow that it actually seems natural in practice.  A side note this works on symbol at point as well as the region but I couldn't think of a better function name to reflect this so just went with helm-pydoc-at-point